### PR TITLE
Feature/delete category

### DIFF
--- a/src/main/java/com/example/cashflow/controller/CategoryController.java
+++ b/src/main/java/com/example/cashflow/controller/CategoryController.java
@@ -1,6 +1,7 @@
 package com.example.cashflow.controller;
 
 import com.example.cashflow.dto.CategoryDTO;
+import com.example.cashflow.form.CategoryForm;
 import com.example.cashflow.service.CategoryService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
@@ -30,8 +31,8 @@ public class CategoryController {
     }
 
     @PostMapping
-    public ResponseEntity<CategoryDTO> insert(@RequestBody CategoryDTO dto) {
-        dto = service.insert(dto);
+    public ResponseEntity<CategoryDTO> insert(@RequestBody CategoryForm form) {
+        CategoryDTO dto = service.insert(form);
         URI uri = ServletUriComponentsBuilder.fromCurrentRequest().path("/{id}")
                 .buildAndExpand(dto.getId()).toUri();
         return ResponseEntity.created(uri).body(dto);

--- a/src/main/java/com/example/cashflow/controller/CategoryController.java
+++ b/src/main/java/com/example/cashflow/controller/CategoryController.java
@@ -43,4 +43,11 @@ public class CategoryController {
         CategoryDTO dto = service.update(id, form);
         return ResponseEntity.ok().body(dto);
     }
+
+    @DeleteMapping(value = "/{id}")
+    public ResponseEntity<Void> delete(@PathVariable Long id) {
+        service.delete(id);
+        return ResponseEntity.noContent().build();
+    }
+
 }

--- a/src/main/java/com/example/cashflow/controller/CategoryController.java
+++ b/src/main/java/com/example/cashflow/controller/CategoryController.java
@@ -37,4 +37,10 @@ public class CategoryController {
                 .buildAndExpand(dto.getId()).toUri();
         return ResponseEntity.created(uri).body(dto);
     }
+
+    @PutMapping(value = "/{id}")
+    public ResponseEntity<CategoryDTO> update(@PathVariable Long id, @RequestBody CategoryForm form) {
+        CategoryDTO dto = service.update(id, form);
+        return ResponseEntity.ok().body(dto);
+    }
 }

--- a/src/main/java/com/example/cashflow/controller/exceptions/ResourceExceptionHandler.java
+++ b/src/main/java/com/example/cashflow/controller/exceptions/ResourceExceptionHandler.java
@@ -1,5 +1,6 @@
 package com.example.cashflow.controller.exceptions;
 
+import com.example.cashflow.service.exceptions.DatabaseException;
 import com.example.cashflow.service.exceptions.ResourceNotFoundException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -19,6 +20,18 @@ public class ResourceExceptionHandler {
         err.setTimestamp(Instant.now());
         err.setStatus(status.value());
         err.setError("Resource not found");
+        err.setMessage(e.getMessage());
+        err.setPath(request.getRequestURI());
+        return ResponseEntity.status(status).body(err);
+    }
+
+    @ExceptionHandler(DatabaseException.class)
+    public ResponseEntity<StandardError> resourceNotFound(DatabaseException e, HttpServletRequest request) {
+        StandardError err = new StandardError();
+        HttpStatus status = HttpStatus.BAD_REQUEST;
+        err.setTimestamp(Instant.now());
+        err.setStatus(status.value());
+        err.setError("Database exception");
         err.setMessage(e.getMessage());
         err.setPath(request.getRequestURI());
         return ResponseEntity.status(status).body(err);

--- a/src/main/java/com/example/cashflow/controller/exceptions/ResourceExceptionHandler.java
+++ b/src/main/java/com/example/cashflow/controller/exceptions/ResourceExceptionHandler.java
@@ -26,7 +26,7 @@ public class ResourceExceptionHandler {
     }
 
     @ExceptionHandler(DatabaseException.class)
-    public ResponseEntity<StandardError> resourceNotFound(DatabaseException e, HttpServletRequest request) {
+    public ResponseEntity<StandardError> database(DatabaseException e, HttpServletRequest request) {
         StandardError err = new StandardError();
         HttpStatus status = HttpStatus.BAD_REQUEST;
         err.setTimestamp(Instant.now());

--- a/src/main/java/com/example/cashflow/form/CategoryForm.java
+++ b/src/main/java/com/example/cashflow/form/CategoryForm.java
@@ -1,0 +1,13 @@
+package com.example.cashflow.form;
+
+import javax.validation.constraints.NotBlank;
+
+public class CategoryForm {
+
+    @NotBlank(message = "The name field cannot be blank")
+    private String name;
+
+    public String getName() { return name; }
+
+    public void setName(String name) { this.name = name; }
+}

--- a/src/main/java/com/example/cashflow/mapper/CategoryMapper.java
+++ b/src/main/java/com/example/cashflow/mapper/CategoryMapper.java
@@ -1,0 +1,11 @@
+package com.example.cashflow.mapper;
+
+import com.example.cashflow.form.CategoryForm;
+import com.example.cashflow.model.Category;
+
+public class CategoryMapper {
+
+    public Category create (CategoryForm form) {
+        return new Category(form.getName());
+    }
+}

--- a/src/main/java/com/example/cashflow/model/Category.java
+++ b/src/main/java/com/example/cashflow/model/Category.java
@@ -23,6 +23,10 @@ public class Category implements Serializable {
         this.name = name;
     }
 
+    public Category(String name) {
+        this.name = name;
+    }
+
     public Long getId() {
         return id;
     }

--- a/src/main/java/com/example/cashflow/model/Category.java
+++ b/src/main/java/com/example/cashflow/model/Category.java
@@ -12,6 +12,7 @@ public class Category implements Serializable {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
+    @Column(nullable = false, length = 150)
     private String name;
 
     public Category() {

--- a/src/main/java/com/example/cashflow/service/CategoryService.java
+++ b/src/main/java/com/example/cashflow/service/CategoryService.java
@@ -11,6 +11,7 @@ import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import javax.persistence.EntityNotFoundException;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -39,5 +40,16 @@ public class CategoryService {
         Category category = new CategoryMapper().create(form);
         category = repository.save(category);
         return new CategoryDTO(category);
+    }
+
+    @Transactional
+    public CategoryDTO update(Long id, CategoryForm form) {
+        try {
+            Category entity = repository.getReferenceById(id);
+            entity.setName(form.getName());
+            return new CategoryDTO(repository.save(entity));
+        } catch (EntityNotFoundException e) {
+            throw new ResourceNotFoundException("Id not found: " + id);
+        }
     }
 }

--- a/src/main/java/com/example/cashflow/service/CategoryService.java
+++ b/src/main/java/com/example/cashflow/service/CategoryService.java
@@ -1,6 +1,8 @@
 package com.example.cashflow.service;
 
 import com.example.cashflow.dto.CategoryDTO;
+import com.example.cashflow.form.CategoryForm;
+import com.example.cashflow.mapper.CategoryMapper;
 import com.example.cashflow.model.Category;
 import com.example.cashflow.repository.CategoryRepository;
 import com.example.cashflow.service.exceptions.ResourceNotFoundException;
@@ -33,10 +35,9 @@ public class CategoryService {
     }
 
     @Transactional
-    public CategoryDTO insert(CategoryDTO dto) {
-        Category entity = new Category();
-        entity.setName(dto.getName());
-        entity = repository.save(entity);
-        return new CategoryDTO(entity);
+    public CategoryDTO insert(CategoryForm form) {
+        Category category = new CategoryMapper().create(form);
+        category = repository.save(category);
+        return new CategoryDTO(category);
     }
 }

--- a/src/main/java/com/example/cashflow/service/CategoryService.java
+++ b/src/main/java/com/example/cashflow/service/CategoryService.java
@@ -63,7 +63,7 @@ public class CategoryService {
         catch (EmptyResultDataAccessException e) {
             throw new ResourceNotFoundException("Id not found: " + id);
         }
-        catch (DataIntegrityViolationException e) {
+            catch (DataIntegrityViolationException e) {
             throw new DatabaseException("Integrity violation");
         }
     }

--- a/src/main/java/com/example/cashflow/service/CategoryService.java
+++ b/src/main/java/com/example/cashflow/service/CategoryService.java
@@ -5,8 +5,11 @@ import com.example.cashflow.form.CategoryForm;
 import com.example.cashflow.mapper.CategoryMapper;
 import com.example.cashflow.model.Category;
 import com.example.cashflow.repository.CategoryRepository;
+import com.example.cashflow.service.exceptions.DatabaseException;
 import com.example.cashflow.service.exceptions.ResourceNotFoundException;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.dao.EmptyResultDataAccessException;
 import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -50,6 +53,18 @@ public class CategoryService {
             return new CategoryDTO(repository.save(entity));
         } catch (EntityNotFoundException e) {
             throw new ResourceNotFoundException("Id not found: " + id);
+        }
+    }
+
+    public void delete(Long id) {
+        try {
+            repository.deleteById(id);
+        }
+        catch (EmptyResultDataAccessException e) {
+            throw new ResourceNotFoundException("Id not found: " + id);
+        }
+        catch (DataIntegrityViolationException e) {
+            throw new DatabaseException("Integrity violation");
         }
     }
 }

--- a/src/main/java/com/example/cashflow/service/exceptions/DatabaseException.java
+++ b/src/main/java/com/example/cashflow/service/exceptions/DatabaseException.java
@@ -1,0 +1,9 @@
+package com.example.cashflow.service.exceptions;
+
+public class DatabaseException extends RuntimeException {
+    private static final long serialVersionUID = 1L;
+
+    public DatabaseException(String msg) {
+        super(msg);
+    }
+}


### PR DESCRIPTION
This PR adds "delete category" functionality to the application. Changes include the implementation of the delete method in the CategoryService and CategoryController.
### Changes Made

- Added the `delete` method to the `CategoryService` and `CategoryController`.
- Created a `DatabaseException` to propagate when an `DataIntegrityViolationException` is caught.
- Implemented an `ExceptionHandler` to handle a `DatabaseException`.

This method has not been annotated with `@Transactional`, as this annotation does not allow catching exceptions coming from the database. Cases of deleting a resource that is linked to another can violate referential integrity if it is a mandatory relationship. In this case, the `DataIntegrityViolationException` exception will be caught and a `DatabaseException` will be propagated, which in turn will be handled in the `ResourceExceptionHandler` by the `database` method.
