### PR TITLE
Feature/delete brand

### DIFF
--- a/src/main/java/com/example/cashflow/controller/BrandController.java
+++ b/src/main/java/com/example/cashflow/controller/BrandController.java
@@ -1,0 +1,24 @@
+package com.example.cashflow.controller;
+
+import com.example.cashflow.dto.BrandDTO;
+import com.example.cashflow.service.BrandService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping(value = "/brands")
+public class BrandController {
+
+    @Autowired
+    private BrandService service;
+
+    @GetMapping
+    public ResponseEntity<List<BrandDTO>> findAll() {
+        return ResponseEntity.ok().body(service.findAll());
+    }
+}

--- a/src/main/java/com/example/cashflow/controller/BrandController.java
+++ b/src/main/java/com/example/cashflow/controller/BrandController.java
@@ -1,14 +1,16 @@
 package com.example.cashflow.controller;
 
 import com.example.cashflow.dto.BrandDTO;
+import com.example.cashflow.dto.CategoryDTO;
+import com.example.cashflow.form.BrandForm;
+import com.example.cashflow.form.CategoryForm;
 import com.example.cashflow.service.BrandService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 
+import java.net.URI;
 import java.util.List;
 
 @RestController
@@ -26,5 +28,13 @@ public class BrandController {
     @GetMapping(value = "/{id}")
     public ResponseEntity<BrandDTO> findById(@PathVariable Long id) {
         return ResponseEntity.ok().body(service.findById(id));
+    }
+
+    @PostMapping
+    public ResponseEntity<BrandDTO> insert(@RequestBody BrandForm form) {
+        BrandDTO dto = service.insert(form);
+        URI uri = ServletUriComponentsBuilder.fromCurrentRequest().path("/{id}")
+                .buildAndExpand(dto.getId()).toUri();
+        return ResponseEntity.created(uri).body(dto);
     }
 }

--- a/src/main/java/com/example/cashflow/controller/BrandController.java
+++ b/src/main/java/com/example/cashflow/controller/BrandController.java
@@ -5,6 +5,7 @@ import com.example.cashflow.service.BrandService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -20,5 +21,10 @@ public class BrandController {
     @GetMapping
     public ResponseEntity<List<BrandDTO>> findAll() {
         return ResponseEntity.ok().body(service.findAll());
+    }
+
+    @GetMapping(value = "/{id}")
+    public ResponseEntity<BrandDTO> findById(@PathVariable Long id) {
+        return ResponseEntity.ok().body(service.findById(id));
     }
 }

--- a/src/main/java/com/example/cashflow/controller/BrandController.java
+++ b/src/main/java/com/example/cashflow/controller/BrandController.java
@@ -37,4 +37,10 @@ public class BrandController {
                 .buildAndExpand(dto.getId()).toUri();
         return ResponseEntity.created(uri).body(dto);
     }
+
+    @PutMapping(value = "/{id}")
+    public ResponseEntity<BrandDTO> update(@PathVariable Long id, @RequestBody BrandForm form) {
+        BrandDTO dto = service.update(id, form);
+        return ResponseEntity.ok().body(dto);
+    }
 }

--- a/src/main/java/com/example/cashflow/controller/BrandController.java
+++ b/src/main/java/com/example/cashflow/controller/BrandController.java
@@ -43,4 +43,10 @@ public class BrandController {
         BrandDTO dto = service.update(id, form);
         return ResponseEntity.ok().body(dto);
     }
+
+    @DeleteMapping(value = "/{id}")
+    public ResponseEntity<Void> delete(@PathVariable Long id) {
+        service.delete(id);
+        return ResponseEntity.noContent().build();
+    }
 }

--- a/src/main/java/com/example/cashflow/dto/BrandDTO.java
+++ b/src/main/java/com/example/cashflow/dto/BrandDTO.java
@@ -1,0 +1,41 @@
+package com.example.cashflow.dto;
+
+import com.example.cashflow.model.Brand;
+
+import java.io.Serializable;
+
+public class BrandDTO implements Serializable {
+    private static final long serialVersionUID = 1L;
+
+    private Long id;
+    private String name;
+
+    public BrandDTO() {
+    }
+
+    public BrandDTO(Long id, String name) {
+        this.id = id;
+        this.name = name;
+    }
+
+    public BrandDTO(Brand entity) {
+        this.id = entity.getId();
+        this.name = entity.getName();
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+}

--- a/src/main/java/com/example/cashflow/form/BrandForm.java
+++ b/src/main/java/com/example/cashflow/form/BrandForm.java
@@ -1,0 +1,13 @@
+package com.example.cashflow.form;
+
+import javax.validation.constraints.NotBlank;
+
+public class BrandForm {
+
+    @NotBlank(message = "The name field cannot be blank")
+    private String name;
+
+    public String getName() { return name; }
+
+    public void setName(String name) { this.name = name; }
+}

--- a/src/main/java/com/example/cashflow/mapper/BrandMapper.java
+++ b/src/main/java/com/example/cashflow/mapper/BrandMapper.java
@@ -1,0 +1,11 @@
+package com.example.cashflow.mapper;
+
+import com.example.cashflow.form.BrandForm;
+import com.example.cashflow.model.Brand;
+
+public class BrandMapper {
+
+    public Brand create (BrandForm form) {
+        return new Brand(form.getName());
+    }
+}

--- a/src/main/java/com/example/cashflow/model/Brand.java
+++ b/src/main/java/com/example/cashflow/model/Brand.java
@@ -1,0 +1,58 @@
+package com.example.cashflow.model;
+
+import javax.persistence.*;
+import java.io.Serializable;
+import java.util.Objects;
+
+@Entity
+@Table(name = "brands")
+public class Brand implements Serializable {
+    private static final long serialVersionUID = 1L;
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    @Column(nullable = false, length = 150)
+    private String name;
+
+    public Brand() {
+    }
+
+    public Brand(Long id, String name) {
+        this.id = id;
+        this.name = name;
+    }
+
+    public Brand(String name) {
+        this.name = name;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        Brand category = (Brand) o;
+        return Objects.equals(id, category.id) && Objects.equals(name, category.name);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id, name);
+    }
+}

--- a/src/main/java/com/example/cashflow/repository/BrandRepository.java
+++ b/src/main/java/com/example/cashflow/repository/BrandRepository.java
@@ -1,0 +1,9 @@
+package com.example.cashflow.repository;
+
+import com.example.cashflow.model.Brand;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface BrandRepository extends JpaRepository<Brand, Long> {
+}

--- a/src/main/java/com/example/cashflow/service/BrandService.java
+++ b/src/main/java/com/example/cashflow/service/BrandService.java
@@ -1,7 +1,13 @@
 package com.example.cashflow.service;
 
 import com.example.cashflow.dto.BrandDTO;
+import com.example.cashflow.dto.CategoryDTO;
+import com.example.cashflow.form.BrandForm;
+import com.example.cashflow.form.CategoryForm;
+import com.example.cashflow.mapper.BrandMapper;
+import com.example.cashflow.mapper.CategoryMapper;
 import com.example.cashflow.model.Brand;
+import com.example.cashflow.model.Category;
 import com.example.cashflow.repository.BrandRepository;
 import com.example.cashflow.service.exceptions.ResourceNotFoundException;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -30,5 +36,12 @@ public class BrandService {
         Optional<Brand> obj = repository.findById(id);
         Brand entity = obj.orElseThrow(() -> new ResourceNotFoundException("Entity not found."));
         return new BrandDTO(entity);
+    }
+
+    @Transactional
+    public BrandDTO insert(BrandForm form) {
+        Brand brand = new BrandMapper().create(form);
+        brand = repository.save(brand);
+        return new BrandDTO(brand);
     }
 }

--- a/src/main/java/com/example/cashflow/service/BrandService.java
+++ b/src/main/java/com/example/cashflow/service/BrandService.java
@@ -19,6 +19,7 @@ public class BrandService {
     @Autowired
     private BrandRepository repository;
 
+    @Transactional(readOnly = true)
     public List<BrandDTO> findAll() {
         List<Brand> brands = repository.findAll(Sort.by(Sort.Direction.ASC, "id"));
         return brands.stream().map(BrandDTO::new).collect(Collectors.toList());

--- a/src/main/java/com/example/cashflow/service/BrandService.java
+++ b/src/main/java/com/example/cashflow/service/BrandService.java
@@ -15,6 +15,7 @@ import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import javax.persistence.EntityNotFoundException;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -43,5 +44,16 @@ public class BrandService {
         Brand brand = new BrandMapper().create(form);
         brand = repository.save(brand);
         return new BrandDTO(brand);
+    }
+
+    @Transactional
+    public BrandDTO update(Long id, BrandForm form) {
+        try {
+            Brand entity = repository.getReferenceById(id);
+            entity.setName(form.getName());
+            return new BrandDTO(repository.save(entity));
+        } catch (EntityNotFoundException e) {
+            throw new ResourceNotFoundException("Id not found: " + id);
+        }
     }
 }

--- a/src/main/java/com/example/cashflow/service/BrandService.java
+++ b/src/main/java/com/example/cashflow/service/BrandService.java
@@ -3,11 +3,14 @@ package com.example.cashflow.service;
 import com.example.cashflow.dto.BrandDTO;
 import com.example.cashflow.model.Brand;
 import com.example.cashflow.repository.BrandRepository;
+import com.example.cashflow.service.exceptions.ResourceNotFoundException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 @Service
@@ -19,5 +22,12 @@ public class BrandService {
     public List<BrandDTO> findAll() {
         List<Brand> brands = repository.findAll(Sort.by(Sort.Direction.ASC, "id"));
         return brands.stream().map(BrandDTO::new).collect(Collectors.toList());
+    }
+
+    @Transactional(readOnly = true)
+    public BrandDTO findById(Long id) {
+        Optional<Brand> obj = repository.findById(id);
+        Brand entity = obj.orElseThrow(() -> new ResourceNotFoundException("Entity not found."));
+        return new BrandDTO(entity);
     }
 }

--- a/src/main/java/com/example/cashflow/service/BrandService.java
+++ b/src/main/java/com/example/cashflow/service/BrandService.java
@@ -9,8 +9,11 @@ import com.example.cashflow.mapper.CategoryMapper;
 import com.example.cashflow.model.Brand;
 import com.example.cashflow.model.Category;
 import com.example.cashflow.repository.BrandRepository;
+import com.example.cashflow.service.exceptions.DatabaseException;
 import com.example.cashflow.service.exceptions.ResourceNotFoundException;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.dao.EmptyResultDataAccessException;
 import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -54,6 +57,18 @@ public class BrandService {
             return new BrandDTO(repository.save(entity));
         } catch (EntityNotFoundException e) {
             throw new ResourceNotFoundException("Id not found: " + id);
+        }
+    }
+
+    public void delete(Long id) {
+        try {
+            repository.deleteById(id);
+        }
+        catch (EmptyResultDataAccessException e) {
+            throw new ResourceNotFoundException("Id not found: " + id);
+        }
+        catch (DataIntegrityViolationException e) {
+            throw new DatabaseException("Integrity violation");
         }
     }
 }

--- a/src/main/java/com/example/cashflow/service/BrandService.java
+++ b/src/main/java/com/example/cashflow/service/BrandService.java
@@ -1,0 +1,23 @@
+package com.example.cashflow.service;
+
+import com.example.cashflow.dto.BrandDTO;
+import com.example.cashflow.model.Brand;
+import com.example.cashflow.repository.BrandRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+public class BrandService {
+
+    @Autowired
+    private BrandRepository repository;
+
+    public List<BrandDTO> findAll() {
+        List<Brand> brands = repository.findAll(Sort.by(Sort.Direction.ASC, "id"));
+        return brands.stream().map(BrandDTO::new).collect(Collectors.toList());
+    }
+}


### PR DESCRIPTION
This PR adds "delete brand" functionality to the application. Changes include the implementation of the delete method in the `BrandService` and `BrandController`.

### Changes Made

- Added the delete method to the `BrandService` and `BrandController`.

This method has not been annotated with `@Transactional`, as this annotation does not allow catching exceptions coming from the database. Cases of deleting a resource that is linked to another can violate referential integrity if it is a mandatory relationship. In this case, the `DataIntegrityViolationException` exception will be caught and a `DatabaseException` will be propagated, which in turn will be handled in the `ResourceExceptionHandler` by the `database` method.